### PR TITLE
Increasing log level of set temperature and set recirculate to "info"

### DIFF
--- a/src/platformAccessory.ts
+++ b/src/platformAccessory.ts
@@ -122,7 +122,7 @@ export class RinnaiControlrPlatformAccessory {
   }
 
   async setRecirculateActive(value: CharacteristicValue) {
-    this.platform.log.debug(`setRecirculateActive to ${value} for device ${this.device.dsn}`);
+    this.platform.log.info(`setRecirculateActive to ${value} for device ${this.device.dsn}`);
     await this.platform.setState(this.accessory, API_KEY_SET_PRIORITY_STATUS, API_VALUE_TRUE);
     if (value as boolean) {
       await this.platform.setState(this.accessory, API_KEY_RECIRCULATION_DURATION, `${this.platform.getConfig().recirculationDuration}`);
@@ -134,7 +134,7 @@ export class RinnaiControlrPlatformAccessory {
   }
 
   async setTemperature(value: CharacteristicValue) {
-    this.platform.log.debug(`setTemperature to ${value} for device ${this.device.dsn}`);
+    this.platform.log.info(`setTemperature to ${value} for device ${this.device.dsn}`);
 
     const convertedValue : number = this.isFahrenheit
       ? Math.round(celsiusToFahrenheit(value as number)/5) * 5 // Round to nearest 5


### PR DESCRIPTION
I think this is pretty standard practice to print log messages whenever an accessory is toggled by Homekit, could we raise these two log messages to `info` level?